### PR TITLE
fix conversation result usage in loadEntireConversation

### DIFF
--- a/WhatsAppWeb.Query.js
+++ b/WhatsAppWeb.Query.js
@@ -102,7 +102,7 @@ module.exports = {
 
         const loadMessage = () => {
             return this.loadConversation(jid, chunkSize, offsetID, mostRecentFirst)
-            .then (json => {
+            .then (([json]) => {
                 if (json[2]) {
                     // callback with most recent message first (descending order of date)
                     let lastMessage


### PR DESCRIPTION
In `loadEntireConversation`, after loading a conversation with `loadConversation`, the resulting `json` variable was an array of `[expectedJson, request]` (from `q.callback([json, q.queryJSON])` in WhatsAppWeb.Recv.js) and was expected to be `expectedJson` only by the following code.