### PR TITLE
Audio decoding based on MIME-type.

### DIFF
--- a/src/WAConnection/6.MessagesSend.ts
+++ b/src/WAConnection/6.MessagesSend.ts
@@ -120,7 +120,7 @@ export class WAConnection extends Base {
         await generateThumbnail(buffer, mediaType, options)
         if (mediaType === MessageType.audio && !options.duration) {
             try {
-                options.duration = await getAudioDuration (buffer)
+                options.duration = await getAudioDuration (buffer, options.mimetype)
             } catch (error) {
                 this.logger.debug ({ error }, 'failed to obtain audio duration: ' + error.message)
             }

--- a/src/WAConnection/Utils.ts
+++ b/src/WAConnection/Utils.ts
@@ -230,9 +230,9 @@ export const mediaMessageSHA256B64 = (message: WAMessageContent) => {
     const media = Object.values(message)[0] as WAGenericMediaMessage
     return media?.fileSha256 && Buffer.from(media.fileSha256).toString ('base64')
 }
-export async function getAudioDuration (buffer: Buffer) {
+export async function getAudioDuration (buffer: Buffer, mimeType: string) {
     const musicMetadata = await import ('music-metadata')
-    const metadata = await musicMetadata.parseBuffer (buffer, null, {duration: true});
+    const metadata = await musicMetadata.parseBuffer (buffer, {mimeType: mimeType}, {duration: true});
     return metadata.format.duration;
 }
 


### PR DESCRIPTION
Use the MIME-type to determine the audio type.
Without the MIME-type [music-metadata](https://github.com/Borewit/music-metadata) will use [file-type](https://github.com/sindresorhus/file-type) to determine the audio type.

Related to #203