### PR TITLE
Fixed event emitter for default callback

### DIFF
--- a/src/WAConnection/3.Connect.ts
+++ b/src/WAConnection/3.Connect.ts
@@ -202,12 +202,15 @@ export class WAConnection extends Base {
             const l0 = json[0] || ''
             const l1 = typeof json[1] !== 'object' || json[1] === null ? {} : json[1]
             const l2 = ((json[2] || [])[0] || [])[0] || ''
+
             Object.keys(l1).forEach(key => {
-                anyTriggered = anyTriggered || this.emit (`${DEF_CALLBACK_PREFIX}${l0},${key}:${l1[key]},${l2}`, json)
-                anyTriggered = anyTriggered || this.emit (`${DEF_CALLBACK_PREFIX}${l0},${key}:${l1[key]}`, json)
+                anyTriggered = this.emit (`${DEF_CALLBACK_PREFIX}${l0},${key}:${l1[key]},${l2}`) || anyTriggered;
+                anyTriggered = this.emit (`${DEF_CALLBACK_PREFIX}${l0},${key}:${l1[key]}`) || anyTriggered;
+                anyTriggered = this.emit (`${DEF_CALLBACK_PREFIX}${l0},${key}`) || anyTriggered;
             })
-            anyTriggered = anyTriggered || this.emit (`${DEF_CALLBACK_PREFIX}${l0},,${l2}`, json)
-            anyTriggered = anyTriggered || this.emit (`${DEF_CALLBACK_PREFIX}${l0}`, json)
+            anyTriggered = this.emit (`${DEF_CALLBACK_PREFIX}${l0},,${l2}`) || anyTriggered;
+            anyTriggered = this.emit (`${DEF_CALLBACK_PREFIX}${l0}`) || anyTriggered;
+
             if (anyTriggered) return
 
             if (this.state === 'open' && json[0] === 'Pong') {


### PR DESCRIPTION
This PR fix the problem with multiple listeners with same kind of callback when only first is emitted.
Example:
* `CB:action,add:update,message`
* `CB:action,add:update`
* `CB:action,add` // new
* `CB:action,,message`
* `CB:action`

Previous this PR, only `CB:action,add:update,message` is emitted

This PR fix the `CB:Conn,pushname` example in README.md too

To test (it takes a while): `npm install github:edgardmessias/Baileys#fix_emit`