### PR TITLE
Fixed: loadMessages And isOnWhatsApp and Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ await conn.sendMessage(
 ### Notes
 
 - `id` is the WhatsApp ID of the person or group you're sending the message to. 
-    - It must be in the format ```[country code][phone number]@s.whatsapp.net```, for example ```19999999999@s.whatsapp.net``` for people. For groups, it must be in the format ``` 123456789-123345@g.us ```. 
+    - It must be in the format ```[country code without +][phone number]@s.whatsapp.net```, for example ```19999999999@s.whatsapp.net``` for people. For groups, it must be in the format ``` 123456789-123345@g.us ```. 
     - For broadcast lists it's `[timestamp of creation]@broadcast`.
     - For stories, the ID is `status@broadcast`.
 - For media messages, the thumbnail can be generated automatically for images & stickers. Thumbnails for videos can also be generated automatically, though, you need to have `ffmpeg` installed on your system.

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ await conn.sendMessage(
 ### Notes
 
 - `id` is the WhatsApp ID of the person or group you're sending the message to. 
-    - It must be in the format ```[country code][phone number]@s.whatsapp.net```, for example ```+19999999999@s.whatsapp.net``` for people. For groups, it must be in the format ``` 123456789-123345@g.us ```. 
+    - It must be in the format ```[country code][phone number]@s.whatsapp.net```, for example ```19999999999@s.whatsapp.net``` for people. For groups, it must be in the format ``` 123456789-123345@g.us ```. 
     - For broadcast lists it's `[timestamp of creation]@broadcast`.
     - For stories, the ID is `status@broadcast`.
 - For media messages, the thumbnail can be generated automatically for images & stickers. Thumbnails for videos can also be generated automatically, though, you need to have `ffmpeg` installed on your system.

--- a/src/WAConnection/5.User.ts
+++ b/src/WAConnection/5.User.ts
@@ -19,32 +19,8 @@ export class WAConnection extends Base {
      * @returns undefined if the number doesn't exists, otherwise the correctly formatted jid
      */
     isOnWhatsApp = async (str: string) => {
-        if (this.state !== 'open') {
-            return this.isOnWhatsAppNoConn(str)
-        }
         const { status, jid, biz } = await this.query({json: ['query', 'exist', str], requiresPhoneConnection: false})
         if (status === 200) return { exists: true, jid: whatsappID(jid), isBusiness: biz as boolean}
-    }
-    /** 
-     * Query whether a given number is registered on WhatsApp, without needing to open a WS connection
-     * @param str phone number/jid you want to check for
-     * @returns undefined if the number doesn't exists, otherwise the correctly formatted jid
-     */
-    isOnWhatsAppNoConn = async (str: string) => {
-        let phone = str.split('@')[0]
-        const url = `https://wa.me/${phone}`
-        const response = await this.fetchRequest(url, 'GET', undefined, undefined, undefined, false)
-        const loc = response.headers.location as string
-        if (!loc) {
-            this.logger.warn({ url, status: response.statusCode }, 'did not get location from request')
-            return
-        }
-        const locUrl = new URL('', loc)
-        if (!locUrl.pathname.endsWith('send/')) {
-            return
-        }
-        phone = locUrl.searchParams.get('phone')
-        return { exists: true, jid: `${phone}@s.whatsapp.net` } 
     }
     /**
      * Tell someone about your presence -- online, typing, offline etc.

--- a/src/WAConnection/7.MessagesExtra.ts
+++ b/src/WAConnection/7.MessagesExtra.ts
@@ -93,6 +93,9 @@ export class WAConnection extends Base {
             null,
         ]
         const response = await this.query({json, binaryTags: [WAMetric.queryMessages, WAFlag.ignore], expect200: false, requiresPhoneConnection: true})
+		if(!indexMessage&&response[2]){
+			response[2] = response[2].slice(1)
+		}
         return (response[2] as WANode[])?.map(item => item[2] as WAMessage) || []
     }
     /**

--- a/src/WAConnection/7.MessagesExtra.ts
+++ b/src/WAConnection/7.MessagesExtra.ts
@@ -93,9 +93,6 @@ export class WAConnection extends Base {
             null,
         ]
         const response = await this.query({json, binaryTags: [WAMetric.queryMessages, WAFlag.ignore], expect200: false, requiresPhoneConnection: true})
-		if(!indexMessage&&response[2]){
-			response[2] = response[2].slice(1)
-		}
         return (response[2] as WANode[])?.map(item => item[2] as WAMessage) || []
     }
     /**


### PR DESCRIPTION
1. `loadMessages` - WA returned count+1 messages in case `indexMessage `  is not specified. This caused wrong number of elements in `loadMessages` and `loadUnreadMessages`. This should fix it.


2. `isOnWhatsAppNoConn` is now broken as the API it relied upon simply does not check if the number is on WhatsApp. So remove it from fallback to avoid false positives. This will now result in an error in case connection is not open. Found in #559.


3. Update Readme as noticed by #564.