### PR TITLE
fix groupSettingChange read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,9 +502,9 @@ Of course, replace ``` xyz ``` with an actual ID.
     // only allow admins to send messages
     await conn.groupSettingChange ("abcd-xyz@g.us", GroupSettingChange.messageSend, true)
     // allow everyone to modify the group's settings -- like display picture etc.
-    await conn.groupSettingChange ("abcd-xyz@g.us", GroupSettingChange.settingChange, false)
+    await conn.groupSettingChange ("abcd-xyz@g.us", GroupSettingChange.settingsChange, false)
     // only allow admins to modify the group's settings
-    await conn.groupSettingChange ("abcd-xyz@g.us", GroupSettingChange.settingChange, true)
+    await conn.groupSettingChange ("abcd-xyz@g.us", GroupSettingChange.settingsChange, true)
     ```
 - To leave a group
     ``` ts


### PR DESCRIPTION
 `groupSettingChange` got `Unexpected status in 'action': Unauthorized(401)`    
Because I wrote the code in JavaScript, I didn’t find the spelling problem of the enum class. 🤣   
In readme:
```JavaScript
  // allow everyone to modify the group's settings -- like display picture etc.
    await conn.groupSettingChange ("abcd-xyz@g.us", GroupSettingChange.settingChange, false)
    // only allow admins to modify the group's settings
    await conn.groupSettingChange ("abcd-xyz@g.us", GroupSettingChange.settingChange, true)
```
In [Source Code](https://github.com/adiwajshing/Baileys/blob/bc4dc9625d65cc872639e4257b509000ca06f8fb/src/WAConnection/Constants.ts#L460):    
```TypeScript
export enum GroupSettingChange {
    messageSend = 'announcement',
    settingsChange = 'locked',
}
```    
This is my mistake, but it would be better to correct it