### PR TITLE
Add explicit types to socket factory functions

### DIFF
--- a/src/LegacySocket/auth.ts
+++ b/src/LegacySocket/auth.ts
@@ -1,10 +1,19 @@
 import { Boom } from '@hapi/boom'
 import EventEmitter from 'events'
-import { ConnectionState, CurveKeyPair, DisconnectReason, LegacyBaileysEventEmitter, LegacySocketConfig, WAInitResponse } from '../Types'
+import { ConnectionState, CurveKeyPair, DisconnectReason, LegacyAuthenticationCreds, LegacyBaileysEventEmitter, LegacySocketConfig, WAInitResponse } from '../Types'
 import { bindWaitForConnectionUpdate, computeChallengeResponse, Curve, newLegacyAuthCreds, printQRIfNecessaryListener, validateNewConnection } from '../Utils'
-import { makeSocket } from './socket'
+import { LegacySocket, makeSocket } from './socket'
 
-const makeAuthSocket = (config: LegacySocketConfig) => {
+export type LegacyAuthSocket = LegacySocket & {
+	state: ConnectionState,
+	authInfo: LegacyAuthenticationCreds,
+	ev: LegacyBaileysEventEmitter,
+	canLogin: () => boolean,
+	logout: () => Promise<void>,
+	waitForConnectionUpdate: (check: (u: Partial<ConnectionState>) => boolean, timeoutMs?: number) => Promise<void>
+}
+
+const makeAuthSocket: (config: LegacySocketConfig) => LegacyAuthSocket = (config: LegacySocketConfig) => {
 	const {
 		logger,
 		version,

--- a/src/LegacySocket/business.ts
+++ b/src/LegacySocket/business.ts
@@ -1,9 +1,17 @@
 import { LegacySocketConfig, OrderDetails } from '../Types'
 import { CatalogResult, Product, ProductCreate, ProductCreateResult, ProductUpdate } from '../Types'
 import { uploadingNecessaryImages } from '../Utils/business'
-import makeGroupsSocket from './groups'
+import makeGroupsSocket, { LegacyGroupsSocket } from './groups'
 
-const makeBusinessSocket = (config: LegacySocketConfig) => {
+export type LegacyBusinessSocket = LegacyGroupsSocket & {
+	getOrderDetails: (orderId: string, tokenBase64: string) => Promise<OrderDetails>;
+	getCatalog: (jid?: string, limit?: number) => Promise<{ beforeCursor: string; products: Product[]; }>;
+	productCreate: (product: ProductCreate) => Promise<Product>;
+	productDelete: (productIds: string[]) => Promise<{ deleted: any; }>;
+	productUpdate: (productId: string, update: ProductUpdate) => Promise<Product>;
+}
+
+const makeBusinessSocket: (config: LegacySocketConfig) => LegacyBusinessSocket = (config: LegacySocketConfig) => {
 	const sock = makeGroupsSocket(config)
 	const {
 		query,

--- a/src/LegacySocket/groups.ts
+++ b/src/LegacySocket/groups.ts
@@ -1,9 +1,20 @@
 import { GroupMetadata, GroupModificationResponse, GroupParticipant, LegacySocketConfig, ParticipantAction, WAFlag, WAGroupCreateResponse, WAMetric } from '../Types'
 import { generateMessageID, unixTimestampSeconds } from '../Utils/generics'
 import { BinaryNode, jidNormalizedUser } from '../WABinary'
-import makeMessagesSocket from './messages'
+import makeMessagesSocket, { LegacyMessagesSocket } from './messages'
 
-const makeGroupsSocket = (config: LegacySocketConfig) => {
+export type LegacyGroupsSocket = LegacyMessagesSocket & {
+	groupMetadata: (jid: string, minimal: boolean) => Promise<GroupMetadata>;
+	groupCreate: (title: string, participants: string[]) => Promise<GroupMetadata>;
+	groupLeave: (id: string) => Promise<void>;
+	groupUpdateSubject: (id: string, title: string) => Promise<void>;
+	groupUpdateDescription: (jid: string, description: string) => Promise<{ status: number; }>;
+	groupParticipantsUpdate: (id: string, participants: string[], action: ParticipantAction) => Promise<string[]>;
+	getBroadcastListInfo: (jid: string) => Promise<GroupMetadata>;
+	groupInviteCode: (jid: string) => Promise<string>;
+}
+
+const makeGroupsSocket: (config: LegacySocketConfig) => LegacyGroupsSocket = (config: LegacySocketConfig) => {
 	const { logger } = config
 	const sock = makeMessagesSocket(config)
 	const {

--- a/src/LegacySocket/socket.ts
+++ b/src/LegacySocket/socket.ts
@@ -429,3 +429,5 @@ export const makeSocket = ({
 		end
 	}
 }
+
+export type LegacySocket = ReturnType<typeof makeSocket>

--- a/src/Socket/business.ts
+++ b/src/Socket/business.ts
@@ -1,10 +1,19 @@
-import { ProductCreate, ProductUpdate, SocketConfig } from '../Types'
+import { CatalogCollection, OrderDetails, Product, ProductCreate, ProductUpdate, SocketConfig } from '../Types'
 import { parseCatalogNode, parseCollectionsNode, parseOrderDetailsNode, parseProductNode, toProductNode, uploadingNecessaryImagesOfProduct } from '../Utils/business'
 import { jidNormalizedUser, S_WHATSAPP_NET } from '../WABinary'
 import { getBinaryNodeChild } from '../WABinary/generic-utils'
-import { makeMessagesRecvSocket } from './messages-recv'
+import { makeMessagesRecvSocket, MessagesRecvSocket } from './messages-recv'
 
-export const makeBusinessSocket = (config: SocketConfig) => {
+export type BusinessSocket = MessagesRecvSocket & {
+	getOrderDetails: (orderId: string, tokenBase64: string) => Promise<OrderDetails>;
+	getCatalog: (jid?: string, limit?: number) => Promise<{ products: Product[]; }>;
+	getCollections: (jid?: string, limit?: number) => Promise<{ collections: CatalogCollection[]; }>;
+	productCreate: (create: ProductCreate) => Promise<Product>;
+	productDelete: (productIds: string[]) => Promise<{ deleted: number; }>;
+	productUpdate: (productId: string, update: ProductUpdate) => Promise<Product>
+}
+
+export const makeBusinessSocket: (config: SocketConfig) => BusinessSocket = (config: SocketConfig) => {
 	const sock = makeMessagesRecvSocket(config)
 	const {
 		authState,

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -1,9 +1,24 @@
 import { GroupMetadata, ParticipantAction, SocketConfig } from '../Types'
 import { generateMessageID } from '../Utils'
 import { BinaryNode, getBinaryNodeChild, getBinaryNodeChildren, jidEncode, jidNormalizedUser } from '../WABinary'
-import { makeSocket } from './socket'
+import { makeSocket, Socket } from './socket'
 
-export const makeGroupsSocket = (config: SocketConfig) => {
+export type GroupsSocket = Socket & {
+	groupMetadata: (jid: string) => Promise<GroupMetadata>,
+	groupCreate: (subject: string, participants: string[]) => Promise<GroupMetadata>;
+	groupLeave: (id: string) => Promise<void>;
+	groupUpdateSubject: (jid: string, subject: string) => Promise<void>;
+	groupParticipantsUpdate: (jid: string, participants: string[], action: ParticipantAction) => Promise<string[]>;
+	groupUpdateDescription: (jid: string, description?: string) => Promise<void>;
+	groupInviteCode: (jid: string) => Promise<string>;
+	groupRevokeInvite: (jid: string) => Promise<string>;
+	groupAcceptInvite: (code: string) => Promise<string>;
+	groupToggleEphemeral: (jid: string, ephemeralExpiration: number) => Promise<void>;
+	groupSettingUpdate: (jid: string, setting: 'announcement' | 'not_announcement' | 'locked' | 'unlocked') => Promise<void>;
+	groupFetchAllParticipating: () => Promise<{ [_: string]: GroupMetadata }>;
+}
+
+export const makeGroupsSocket: (config: SocketConfig) => GroupsSocket = (config: SocketConfig) => {
 	const sock = makeSocket(config)
 	const { query } = sock
 

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -5,10 +5,16 @@ import { Chat, GroupMetadata, MessageUserReceipt, ParticipantAction, SocketConfi
 import { decodeMessageStanza, downloadAndProcessHistorySyncNotification, encodeBigEndian, generateSignalPubKey, normalizeMessageContent, toNumber, xmppPreKey, xmppSignedPreKey } from '../Utils'
 import { makeKeyedMutex, makeMutex } from '../Utils/make-mutex'
 import { areJidsSameUser, BinaryNode, BinaryNodeAttributes, getAllBinaryNodeChildren, getBinaryNodeChildren, isJidGroup, jidDecode, jidEncode, jidNormalizedUser } from '../WABinary'
-import { makeChatsSocket } from './chats'
+import { ChatsSocket, makeChatsSocket } from './chats'
 import { extractGroupMetadata } from './groups'
 
-export const makeMessagesRecvSocket = (config: SocketConfig) => {
+export type MessagesRecvSocket = ChatsSocket & {
+	processMessage: (message: proto.IWebMessageInfo, chatUpdate: Partial<Chat>) => Promise<void>,
+	sendMessageAck: ({ tag, attrs }: BinaryNode, extraAttrs: BinaryNodeAttributes) => Promise<void>,
+	sendRetryRequest: (node: BinaryNode) => Promise<void>
+}
+
+export const makeMessagesRecvSocket: (config: SocketConfig) => MessagesRecvSocket = (config: SocketConfig) => {
 	const { logger } = config
 	const sock = makeChatsSocket(config)
 	const {


### PR DESCRIPTION
Add explicit types to socket factory functions. This prevents TypeScript error TS2742 being raised when Baileys is a dependency of another project.