### PR TITLE
fix #1220 prevent process from crashing if logged out during appState sync

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -136,6 +136,8 @@ export const makeSocket = ({
 				},
 			)
 			return result as any
+		} catch (e) {
+			end(new Boom(e))
 		} finally {
 			ws.off(`TAG:${msgId}`, onRecv)
 			ws.off('close', onErr) // if the socket closes, you'll never receive the message


### PR DESCRIPTION
there is an issue discussed in #1220 due to the promise throwing which however does not catch anywhere. this leads to the process finishing.

steps to reproduce the issue without the commit:
- scan a qr with Baileys
- shortly after reconnecting, remove the device
- Baileys will quit due to the error

if you use the commit:
- your process survives and the only "issue" that arises are a few pino logs for the old session that should stop after about 3 minutes


this is useful for people who manage multiple sessions in one process or don't want to manually restart the process every time something happens


**please note that I have not tried this in production for very long myself yet**. adi you know this code better than me - if there are situations where it's actually a useful thing to have the process crashing please tell me. like idk if there are unknown side effects with my changes