### PR TITLE
Fix empty file written in saveState

### DIFF
--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -115,18 +115,22 @@ export const initAuthCreds = (): AuthenticationCreds => {
 /** stores the full authentication state in a single JSON file */
 export const useSingleFileAuthState = (filename: string, logger?: Logger): { state: AuthenticationState, saveState: () => void } => {
 	// require fs here so that in case "fs" is not available -- the app does not crash
-	const { readFileSync, writeFileSync, existsSync } = require('fs')
+	const { readFileSync, writeFileSync, existsSync, renameSync } = require('fs')
 	let creds: AuthenticationCreds
 	let keys: any = { }
 
 	// save the authentication state to a file
 	const saveState = () => {
 		logger && logger.trace('saving auth state')
+
+		let temporaryFilename = `${filename}.temp`
+
 		writeFileSync(
-			filename,
+			temporaryFilename,
 			// BufferJSON replacer utility saves buffers nicely
 			JSON.stringify({ creds, keys }, BufferJSON.replacer, 2)
 		)
+		renameSync(temporaryFilename, filename)
 	}
 
 	if(existsSync(filename)) {


### PR DESCRIPTION
Hi when you close the process during writing it will leave the auth_info_multi.json file empty. The write is not atomic so it can happen.

Now we first write to a temp file and once that's done we replace the real file with the temp file. 

This means that if the process closes we still have our original auth_info_multi.json instead of losing all credentials. It may be in an older state but at least it's not trashing the whole session entirely, we can still reconnect with an outdated json.

Reference:

https://stackoverflow.com/a/39060492/17502680
https://stackoverflow.com/a/26262644