### PR TITLE
Delete auth file on logout in examples

### DIFF
--- a/Example/example-legacy.ts
+++ b/Example/example-legacy.ts
@@ -1,6 +1,7 @@
 import { Boom } from '@hapi/boom'
 import { AnyMessageContent, delay, DisconnectReason, fetchLatestBaileysVersion, makeInMemoryStore, makeWALegacySocket, useSingleFileLegacyAuthState } from '../src'
 import MAIN_LOGGER from '../src/Utils/logger'
+import * as fs from 'fs';
 
 const logger = MAIN_LOGGER.child({ })
 logger.level = 'debug'
@@ -67,6 +68,8 @@ const startSock = async() => {
 			if((lastDisconnect.error as Boom)?.output?.statusCode !== DisconnectReason.loggedOut) {
 				startSock()
 			} else {
+				// delete auth file
+				fs.unlinkSync('./auth_info.json')
 				console.log('connection closed')
 			}
 		}

--- a/Example/example.ts
+++ b/Example/example.ts
@@ -1,6 +1,7 @@
 import { Boom } from '@hapi/boom'
 import makeWASocket, { AnyMessageContent, delay, DisconnectReason, fetchLatestBaileysVersion, makeInMemoryStore, useSingleFileAuthState } from '../src'
 import MAIN_LOGGER from '../src/Utils/logger'
+import * as fs from 'fs';
 
 const logger = MAIN_LOGGER.child({ })
 logger.level = 'trace'
@@ -81,6 +82,8 @@ const startSock = async() => {
 			if((lastDisconnect.error as Boom)?.output?.statusCode !== DisconnectReason.loggedOut) {
 				startSock()
 			} else {
+				// delete auth file
+				fs.unlinkSync('./auth_info_multi.json')
 				console.log('Connection closed. You are logged out.')
 			}
 		}


### PR DESCRIPTION
There is lots of issue i see in this community about connecting and authenticating the whatsapp session.

One of the problems that confused me alot is about when log out happens from whatsapp app, the auth file should be deleted to create the new one of it.
So i fixed it in the examples for others to pay attention to that 