### PR TITLE
Add Example of Redis Session Store Implementation

### DIFF
--- a/Example/example-session-redis-storage.ts
+++ b/Example/example-session-redis-storage.ts
@@ -1,0 +1,124 @@
+import Redis from 'ioredis'
+import makeSocket, { AuthenticationCreds, AuthenticationState, Browsers, BufferJSON, DisconnectReason, initAuthCreds, proto, SignalDataTypeMap } from '../src'
+
+const redis = new Redis({
+	port: 6379,
+	host: '127.0.0.1'
+})
+
+const KEY_MAP: { [T in keyof SignalDataTypeMap]: string } = {
+	'pre-key': 'preKeys',
+	'session': 'sessions',
+	'sender-key': 'senderKeys',
+	'app-state-sync-key': 'appStateSyncKeys',
+	'app-state-sync-version': 'appStateVersions',
+	'sender-key-memory': 'senderKeyMemory'
+}
+
+const useRedisAuthState = async(keyName: string): Promise<{ state: AuthenticationState, saveState: () => Promise<void>, clearState: () => Promise<void> }> => {
+	let creds: AuthenticationCreds
+	let keys: any = {}
+
+	// fetch from redis first
+	const storedCreds = await redis.get(keyName)
+	if(storedCreds) {
+		// if exist, we'll fill the creds and keys
+		const parsedCreds = JSON.parse(storedCreds, BufferJSON.reviver)
+		creds = parsedCreds.creds
+		keys = parsedCreds.keys
+	} else {
+		// if not exist, initialize
+		creds = initAuthCreds()
+	}
+
+	const saveState = async() => {
+		// save creds & keys to redis
+		await redis.set(keyName, JSON.stringify({
+			creds,
+			keys,
+		}, BufferJSON.replacer, 2))
+	}
+
+	const clearState = async() => {
+		await redis.del(keyName)
+	}
+
+	return {
+		state: {
+			creds,
+			keys: {
+				get: (type, ids) => {
+					const key = KEY_MAP[type]
+					return ids.reduce(
+						(dict: any, id) => {
+							let value = keys[key]?.[id]
+							if(value) {
+								if(type === 'app-state-sync-key') {
+									value = proto.AppStateSyncKeyData.fromObject(value)
+								}
+
+								dict[id] = value
+							}
+
+							return dict
+						}, { }
+					)
+				},
+				set: (data: any) => {
+					for(const _key in data) {
+						const key = KEY_MAP[_key as keyof SignalDataTypeMap]
+						keys[key] = keys[key] || { }
+						Object.assign(keys[key], data[_key])
+					}
+
+					saveState()
+				}
+			}
+		},
+		saveState,
+		clearState,
+	}
+}
+
+
+const startSock = async() => {
+	const myRedisKey = 'myWAKey'
+	const { state, saveState, clearState } = await useRedisAuthState(myRedisKey)
+	const sock = makeSocket({
+		auth: state,
+		browser: Browsers.ubuntu('Chrome'),
+		printQRInTerminal: true,
+	})
+
+	sock.ev.on('creds.update', saveState)
+
+	sock.ev.on('connection.update', (update) => {
+		const { connection, lastDisconnect } = update
+
+		if(connection === 'close') {
+			const shouldReconnect = (lastDisconnect as any).error?.output?.statusCode !== DisconnectReason.loggedOut
+			console.log('connection closed due to ', (lastDisconnect as any).error, ', reconnecting ', shouldReconnect)
+			if(shouldReconnect) {
+				return startSock()
+			}
+
+			const isUnauthorized = (lastDisconnect as any).error?.output?.statusCode === DisconnectReason.loggedOut
+			const isDeviceRemoved = (lastDisconnect as any).error?.data?.content?.find((item: any) => item.attrs?.type === 'device_removed') !== undefined
+			// clear stored auth if logout / unauthorized
+			if(isUnauthorized && isDeviceRemoved) {
+				console.info('Clearing state redis')
+				clearState()
+			}
+		} else if(connection === 'open') {
+			console.info('Connection ready!')
+		}
+	})
+
+	sock.ev.on('messages.upsert', async m => {
+		console.log(`------ messages.upsert ------
+    ${JSON.stringify(m, undefined, 2)}
+    ------ messages.upsert ------`)
+	})
+}
+
+startSock()

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ sock.ev.on ('creds.update', saveState)
 
 **Note**: When a message is received/sent, due to signal sessions needing updating, the auth keys (`authState.keys`) will update. Whenever that happens, you must save the updated keys. Not doing so will prevent your messages from reaching the recipient & other unexpected consequences. The `useSingleFileAuthState` function automatically takes care of that, but for any other serious implementation -- you will need to be very careful with the key state management.
 
+**Example Redis**: You may take a look the redis storage implementation at `./Example/example-session-redis-storage.ts` to acquire, update & remove the authentication state data.
+
 ## Listening to Connection Updates
 
 Baileys now fires the `connection.update` event to let you know something has updated in the connection. This data has the following structure:

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/sharp": "^0.29.4",
     "@types/ws": "^8.0.0",
     "eslint": "^7.0.0",
+    "ioredis": "^5.0.4",
     "jest": "^27.0.6",
     "jimp": "^0.16.1",
     "qrcode-terminal": "^0.12.0",


### PR DESCRIPTION
This PR will add an example of session storage with Redis and update the documentation. 

The implementation includes
1. Create new session data to redis if not exist (based on key `myWAKey`)
2. Recover session data from redis if exist
3. Delete session data on redis if device removed from phone.