### PR TITLE
Allow yarn through github installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "test": "jest",
     "prepare": "tsc",
+    "prepack": "tsc",
     "build:all": "tsc && typedoc",
     "build:docs": "typedoc",
     "build:tsc": "tsc",


### PR DESCRIPTION
Reference:
https://yarnpkg.com/advanced/rulebook#packages-should-use-the-prepack-script-to-generate-dist-files-before-publishing