### PR TITLE
Add 'extras' to groupParticipantsUpdate

### DIFF
--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -99,7 +99,7 @@ export const makeGroupsSocket = (config: SocketConfig) => {
 			)
 			const node = getBinaryNodeChild(result, action)
 			const participantsAffected = getBinaryNodeChildren(node!, 'participant')
-			participantsAffected.forEach(participant => {
+			participantsAffected.map(participant => {
 				let data = {status: participant.attrs.error || 200, jid: participant.attrs.jid}
 				if (action == 'add' && participant.attrs.error) {
 					data["extras"] = getBinaryNodeChildren(participant, 'add_request').map((d)=> d.attrs)

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -100,9 +100,9 @@ export const makeGroupsSocket = (config: SocketConfig) => {
 			const node = getBinaryNodeChild(result, action)
 			const participantsAffected = getBinaryNodeChildren(node!, 'participant')
 			return participantsAffected.map(p => {
-				return { status: p.attrs.error || 200, jid: p.attrs.jid }
+				return { status: p.attrs.error || 200, jid: p.attrs.jid, extras: action == 'add' && p.attrs.error ? getBinaryNodeChildren(p, 'add_request').map((d)=> d.attrs) : false}
 			})
-		},
+				},
 		groupUpdateDescription: async(jid: string, description?: string) => {
 			const metadata = await groupMetadata(jid)
 			const prev = metadata.descId ?? null

--- a/src/Socket/groups.ts
+++ b/src/Socket/groups.ts
@@ -99,8 +99,12 @@ export const makeGroupsSocket = (config: SocketConfig) => {
 			)
 			const node = getBinaryNodeChild(result, action)
 			const participantsAffected = getBinaryNodeChildren(node!, 'participant')
-			return participantsAffected.map(p => {
-				return { status: p.attrs.error || 200, jid: p.attrs.jid, extras: action == 'add' && p.attrs.error ? getBinaryNodeChildren(p, 'add_request').map((d)=> d.attrs) : false}
+			participantsAffected.forEach(participant => {
+				let data = {status: participant.attrs.error || 200, jid: participant.attrs.jid}
+				if (action == 'add' && participant.attrs.error) {
+					data["extras"] = getBinaryNodeChildren(participant, 'add_request').map((d)=> d.attrs)
+				}
+				return data;
 			})
 				},
 		groupUpdateDescription: async(jid: string, description?: string) => {


### PR DESCRIPTION
The feature added a new object inside groupParticipantsUpdate object result, which contains the invite code and expiration timestamp while adding a new participant to a group. 