### PR TITLE
Lost connection code correction

### DIFF
--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -49,6 +49,7 @@ export enum DisconnectReason {
     connectionClosed = 428,
     connectionReplaced = 440,
     badSession = 500,
+    banned = 503,
     restartRequired = 515,
 }
 

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -43,7 +43,8 @@ export type UserFacingSocketConfig = Partial<SocketConfig> & { auth: Authenticat
 
 export enum DisconnectReason {
     loggedOut = 401,
-    connectionLost = 403,
+    connectionTerminated = 403,
+    connectionLost = 408,
     timedOut = 408,
     multideviceMismatch = 411,
     connectionClosed = 428,

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -42,14 +42,14 @@ export type SocketConfig = CommonSocketConfig<AuthenticationState> & {
 export type UserFacingSocketConfig = Partial<SocketConfig> & { auth: AuthenticationState }
 
 export enum DisconnectReason {
-	connectionClosed = 428,
-	connectionLost = 408,
-    connectionReplaced = 440,
+    loggedOut = 401,
+    connectionLost = 403,
     timedOut = 408,
-	loggedOut = 401,
+    multideviceMismatch = 411,
+    connectionClosed = 428,
+    connectionReplaced = 440,
     badSession = 500,
     restartRequired = 515,
-    multideviceMismatch = 411
 }
 
 export type WAInitResponse = {


### PR DESCRIPTION
The lost connection code, which can be defined as a banned connection as well, was with the same code as ```timedOut```, I adjusted the order of the codes, and define ```connectionLost``` as code 403, returned when the connection is lost.