### PR TITLE
feat: add notification node type `picture`

### DIFF
--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -194,7 +194,8 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 		const [child] = getAllBinaryNodeChildren(node)
 		const nodeType = node.attrs.type
 
-		if(nodeType === 'w:gp2') {
+		switch (nodeType) {
+		case 'w:gp2':
 			switch (child?.tag) {
 			case 'create':
 				const metadata = extractGroupMetadata(child)
@@ -256,23 +257,40 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 				break
 
 			}
-		} else if(nodeType === 'mediaretry') {
+
+			break
+		case 'mediaretry':
 			const event = decodeMediaRetryNode(node)
 			ev.emit('messages.media-update', [event])
-		} else if(nodeType === 'encrypt') {
+			break
+		case 'encrypt':
 			await handleEncryptNotification(node)
-		} else if(nodeType === 'devices') {
+			break
+		case 'devices':
 			const devices = getBinaryNodeChildren(child, 'device')
 			if(areJidsSameUser(child.attrs.jid, authState.creds!.me!.id)) {
 				const deviceJids = devices.map(d => d.attrs.jid)
 				logger.info({ deviceJids }, 'got my own devices')
 			}
-		} else if(nodeType === 'server_sync') {
+
+			break
+		case 'server_sync':
 			const update = getBinaryNodeChild(node, 'collection')
 			if(update) {
 				const name = update.attrs.name as WAPatchName
 				await resyncAppState([name], undefined)
 			}
+
+			break
+		case 'picture':
+			const setPicture = getBinaryNodeChild(node, 'set')
+			if(setPicture) {
+				result.messageStubType = WAMessageStubType.GROUP_CHANGE_ICON
+				result.messageStubParameters = [ setPicture.attrs.id ]
+				result.participant = setPicture.attrs.author
+			}
+
+			break
 		}
 
 		if(Object.keys(result).length) {
@@ -430,7 +448,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 							id: node.attrs.id,
 							...(msg.key || {})
 						}
-						msg.participant = node.attrs.participant
+						msg.participant ??= node.attrs.participant
 						msg.messageTimestamp = +node.attrs.t
 
 						const fullMsg = proto.WebMessageInfo.fromObject(msg)


### PR DESCRIPTION
this pull request adds support for the notification node type `picture`
this notification is fired whenever someone changes the group's picture

when your group already has a picture and it's changed to a new one, the message would have the `photoChange` property
`photoChange` contains the thumbnail of the old and new picture
this property is only available when you first sync the messages; the notification doesn't have the necessary data to create it
since this isn't feasible (right now), no additional message processing is needed

additionally, this pull request also changes the chain of `else if`'s to a `switch` for more visibility

the notification looks like:
```json
    "frame": {
      "tag": "notification",
      "attrs": {
        "from": "group jid",
        "type": "picture",
        "id": "2797004126",
        "notify": "notify name",
        "t": "1664163305"
      },
      "content": [
        {
          "tag": "set",
          "attrs": {
            "author": "jid of who changed",
            "jid": "group jid",
            "id": "1664163304"
          }
        }
      ]
    }
```

the message looks like:
```json
      "participant": "jid of who changed",
      "messageStubType": "GROUP_CHANGE_ICON",
      "messageStubParameters": [
        "1664163304"
      ],
```
