### PR TITLE
fix(#2365): checking the value of the quotedMsg variable

### DIFF
--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -478,7 +478,7 @@ export const generateWAMessageFromContent = (
 		let quotedMsg = normalizeMessageContent(quoted.message)!
 		const msgType = getContentType(quotedMsg)!
 		// strip any redundant properties
-		quotedMsg = proto.Message.fromObject({ [msgType]: quotedMsg[msgType] })
+		quotedMsg = proto.Message.fromObject({ [msgType]: quotedMsg ? quotedMsg[msgType] : undefined })
 
 		const quotedContent = quotedMsg[msgType]
 		if(typeof quotedContent === 'object' && quotedContent && 'contextInfo' in quotedContent) {


### PR DESCRIPTION
in my case it was triggered when i remove someone from group or add someone to group.

Sample code to trigger the bug:

```javascript
sock.env.on("message.upsert", async (m) => {
   const msg = m.messages[0];
   await sock.sendMessage(msg.key.remoteJid, { text: "Ping!" }, { quoted: msg });
   // try to add someone to a group or remove someone from a group
});
```