### PR TITLE
improve normalizeMessageContent

### DIFF
--- a/src/Tests/test.messages.ts
+++ b/src/Tests/test.messages.ts
@@ -1,0 +1,37 @@
+import { WAMessageContent } from '../Types'
+import { normalizeMessageContent } from '../Utils'
+
+describe('Messages Tests', () => {
+
+	it('should correctly unwrap messages', () => {
+		const CONTENT = { imageMessage: { } }
+		expectRightContent(CONTENT)
+		expectRightContent({
+			ephemeralMessage: { message: CONTENT }
+		})
+		expectRightContent({
+			viewOnceMessage: {
+				message: {
+					ephemeralMessage: { message: CONTENT }
+				}
+			}
+		})
+		expectRightContent({
+			viewOnceMessage: {
+				message: {
+					viewOnceMessageV2: {
+						message: {
+							ephemeralMessage: { message: CONTENT }
+						}
+					}
+				}
+			}
+		})
+
+		function expectRightContent(content: WAMessageContent) {
+			expect(
+				normalizeMessageContent(content)
+			).toHaveProperty('imageMessage')
+		}
+	})
+})

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -573,19 +573,27 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 		return undefined
 	}
 
-	for(;;) {
-		const inner = content?.ephemeralMessage?.message ||
-			content?.viewOnceMessage?.message ||
-			content?.viewOnceMessageV2?.message ||
-			content?.documentWithCaptionMessage?.message
-		if(inner) {
-			content = inner
-		} else {
+	// set max iterations to prevent an infinite loop
+	for(let i = 0;i < 5;i++) {
+		const inner = getFutureProofMessage(content)
+		if(!inner) {
 			break
 		}
+
+		content = inner.message
 	}
 
 	return content!
+
+	function getFutureProofMessage(message: typeof content) {
+		return (
+			message?.ephemeralMessage
+			|| message?.viewOnceMessage
+			|| message?.documentWithCaptionMessage
+			|| message?.viewOnceMessageV2
+			|| message?.editedMessage
+		)
+	}
 }
 
 /**

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -733,7 +733,6 @@ export const downloadMediaMessage = async(
 		const contentType = getContentType(mContent)
 		let mediaType = contentType?.replace('Message', '') as MediaType
 		const media = mContent[contentType!]
-		console.log({ mContent, contentType, media })
 
 		if(!media || typeof media !== 'object' || (!('url' in media) && !('thumbnailDirectPath' in media))) {
 			throw new Boom(`"${contentType}" message is not a media message`)

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -576,6 +576,7 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 	for(;;) {
 		const inner = content?.ephemeralMessage?.message ||
 			content?.viewOnceMessage?.message ||
+			content?.viewOnceMessageV2?.message ||
 			content?.documentWithCaptionMessage?.message
 		if(inner) {
 			content = inner

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -576,7 +576,7 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 	for(;;) {
 		const [key] = Object.keys(content!)
 		const inner = content![key].message
-		if(!inner) {
+		if(inner) {
 			content = inner
 		} else {
 			break

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -574,8 +574,9 @@ export const normalizeMessageContent = (content: WAMessageContent | null | undef
 	}
 
 	for(;;) {
-		const [key] = Object.keys(content!)
-		const inner = content![key].message
+		const inner = content?.ephemeralMessage?.message ||
+			content?.viewOnceMessage?.message ||
+			content?.documentWithCaptionMessage?.message
 		if(inner) {
 			content = inner
 		} else {

--- a/src/Utils/messages.ts
+++ b/src/Utils/messages.ts
@@ -569,13 +569,21 @@ export const getContentType = (content: WAProto.IMessage | undefined) => {
  * @returns
  */
 export const normalizeMessageContent = (content: WAMessageContent | null | undefined): WAMessageContent | undefined => {
-	content = content?.ephemeralMessage?.message?.viewOnceMessage?.message ||
-				content?.ephemeralMessage?.message ||
-				content?.viewOnceMessage?.message ||
-				content?.documentWithCaptionMessage?.message ||
-				content ||
-				undefined
-	return content
+	if(!content) {
+		return undefined
+	}
+
+	for(;;) {
+		const [key] = Object.keys(content!)
+		const inner = content![key].message
+		if(!inner) {
+			content = inner
+		} else {
+			break
+		}
+	}
+
+	return content!
 }
 
 /**
@@ -725,6 +733,7 @@ export const downloadMediaMessage = async(
 		const contentType = getContentType(mContent)
 		let mediaType = contentType?.replace('Message', '') as MediaType
 		const media = mContent[contentType!]
+		console.log({ mContent, contentType, media })
 
 		if(!media || typeof media !== 'object' || (!('url' in media) && !('thumbnailDirectPath' in media))) {
 			throw new Boom(`"${contentType}" message is not a media message`)


### PR DESCRIPTION
This fixes a few issues such as `"documentWithCaptionMessage" message is not a media message` in `downloadMediaMessage` for a message with this shape:

```json
{
  "key": {},
  "message": {
    "ephemeralMessage": {
      "message": {
        "documentWithCaptionMessage": {
          "message": {
            "documentMessage": {}
          }
        }
      }
    }
  },
}
```