### PR TITLE
Bugfix: "mutex start" warns are not on correct logger instance

### DIFF
--- a/src/Socket/chats.ts
+++ b/src/Socket/chats.ts
@@ -34,7 +34,7 @@ export const makeChatsSocket = (config: SocketConfig) => {
 	let needToFlushWithAppStateSync = false
 	let pendingAppStateSync = false
 	/** this mutex ensures that the notifications (receipts, messages etc.) are processed in order */
-	const processingMutex = makeMutex()
+	const processingMutex = makeMutex(logger)
 
 	/** helper function to fetch the given app state sync key */
 	const getAppStateSyncKey = async(keyId: string) => {

--- a/src/Socket/messages-recv.ts
+++ b/src/Socket/messages-recv.ts
@@ -34,7 +34,7 @@ export const makeMessagesRecvSocket = (config: SocketConfig) => {
 	} = sock
 
 	/** this mutex ensures that each retryRequest will wait for the previous one to finish */
-	const retryMutex = makeMutex()
+	const retryMutex = makeMutex(logger)
 
 	const msgRetryMap = config.msgRetryCounterMap || { }
 	const callOfferData: { [id: string]: WACallEvent } = { }

--- a/src/Utils/baileys-event-stream.ts
+++ b/src/Utils/baileys-event-stream.ts
@@ -1,6 +1,7 @@
 import EventEmitter from 'events'
 import { createReadStream } from 'fs'
 import { writeFile } from 'fs/promises'
+import type { Logger } from 'pino'
 import { createInterface } from 'readline'
 import type { BaileysEventEmitter } from '../Types'
 import { delay } from './generics'
@@ -11,10 +12,10 @@ import { makeMutex } from './make-mutex'
  * @param ev The event emitter to read events from
  * @param filename File to save to
  */
-export const captureEventStream = (ev: BaileysEventEmitter, filename: string) => {
+export const captureEventStream = (ev: BaileysEventEmitter, filename: string, logger: Logger) => {
 	const oldEmit = ev.emit
 	// write mutex so data is appended in order
-	const writeMutex = makeMutex()
+	const writeMutex = makeMutex(logger)
 	// monkey patch eventemitter to capture all events
 	ev.emit = function(...args: any[]) {
 		const content = JSON.stringify({ timestamp: Date.now(), event: args[0], data: args[1] }) + '\n'

--- a/src/Utils/make-mutex.ts
+++ b/src/Utils/make-mutex.ts
@@ -1,8 +1,8 @@
-import logger from './logger'
+import type { Logger } from "pino"
 
 const MUTEX_TIMEOUT_MS = 60_000
 
-export const makeMutex = () => {
+export const makeMutex = (logger: Logger) => {
 	let task = Promise.resolve() as Promise<any>
 
 	let taskTimeout: NodeJS.Timeout | undefined
@@ -40,13 +40,13 @@ export const makeMutex = () => {
 
 export type Mutex = ReturnType<typeof makeMutex>
 
-export const makeKeyedMutex = () => {
+export const makeKeyedMutex = (logger: Logger) => {
 	const map: { [id: string]: Mutex } = {}
 
 	return {
 		mutex<T>(key: string, task: () => Promise<T> | T): Promise<T> {
 			if(!map[key]) {
-				map[key] = makeMutex()
+				map[key] = makeMutex(logger)
 			}
 
 			return map[key].mutex(task)


### PR DESCRIPTION
Hello,

Regarding the issue at #2369 

Mutex start error is not logged through to the actual "pino" Logger instance, instead imports the pino Logger from scratch and overrides what the user preference of log warning levels, even when the `logger.level = "fatal"` is specificed, that mutex (logger.warn) is displayed on the terminal. This is pretty annoying when running multiple baileys instances in the same node process.

The solution is to use the "user-created logger instance", and pass it to the "makeMutex" function, which is how it is done for the rest of the app

Tested it locally and on my production server, which runs several hundreds of instances of baileys instances and those mutex warns are no longer bloating the logs.

Yet, why so many mutex start warns are happening, especially during rush hours of WhatsApp, is another question to be solved later