### PR TITLE
fix: messages.upsert

### DIFF
--- a/src/Utils/event-buffer.ts
+++ b/src/Utils/event-buffer.ts
@@ -133,7 +133,6 @@ export const makeEventBuffer = (logger: Logger): BaileysBufferableEventEmitter =
 		emit<T extends BaileysEvent>(event: BaileysEvent, evData: BaileysEventMap[T]) {
 			if(buffersInProgress && BUFFERABLE_EVENT_SET.has(event)) {
 				append(data, historyCache, event as any, evData, logger)
-				return true
 			}
 
 			return ev.emit('event', { [event]: evData })


### PR DESCRIPTION
As I had reported here #2503, I was having problems receiving messages through the messages.upsert event. When I connected the device for the first time, it worked normally, but when I connected for the second time through the authentication credentials, the event stopped working, so debugging the code in order to solve my problem, I saw that there was a return preventing the event from being triggered, so I removed it. I make it clear that I don't know if this has any impact in general in the context of the application but it worked for me