### PR TITLE
Set linkPreview with undefined

### DIFF
--- a/src/Types/Message.ts
+++ b/src/Types/Message.ts
@@ -123,7 +123,7 @@ export type WASendableProduct = Omit<proto.Message.ProductMessage.IProductSnapsh
 export type AnyRegularMessageContent = (
     ({
 	    text: string
-        linkPreview?: WAUrlInfo | null
+        linkPreview?: WAUrlInfo | undefined
     }
     & Mentionable & Buttonable & Templatable & Listable)
     | AnyMediaMessageContent


### PR DESCRIPTION
In generateWAMessageContent, it is checked if it is undefined, and not if it is null.

https://github.com/adiwajshing/Baileys/blob/7923233829f6a5fd1a53059ae6f6eb2b6d222782/src/Utils/messages.ts#L288