### PR TITLE
fix: Fixed send message in new groups

### DIFF
--- a/src/Utils/auth-utils.ts
+++ b/src/Utils/auth-utils.ts
@@ -107,11 +107,13 @@ export const addTransactionCapability = (
 			dbQueriesInTransaction += 1
 			const result = await state.get(type, idsRequiringFetch)
 
-			transactionCache[type] ||= {}
-			transactionCache[type] = Object.assign(
-				transactionCache[type]!,
-				result
-			)
+			if(!transactionCache[type] && result) {
+				transactionCache[type] ||= {}
+				transactionCache[type] = Object.assign(
+					transactionCache[type]!,
+					result
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION

This pr fixed a problem sending message to groups.


```txt
/app/node_modules/@adiwajshing/baileys/WASignalGroup/group_session_builder.js:27
    if (senderKeyRecord.isEmpty()) {

TypeError: Cannot read properties of undefined (reading 'isEmpty')
    at GroupSessionBuilder.create (/app/node_modules/@adiwajshing/baileys/WASignalGroup/group_session_builder.js:27:25)
    at async Object.encryptGroupMessage (/app/node_modules/@adiwajshing/baileys/lib/Signal/libsignal.js:79:50)
    at async /app/node_modules/@adiwajshing/baileys/lib/Socket/messages-send.js:317:70
    at async Object.transaction (/app/node_modules/@adiwajshing/baileys/lib/Utils/auth-utils.js:145:21)
    at async relayMessage (/app/node_modules/@adiwajshing/baileys/lib/Socket/messages-send.js:288:9)
    at async Object.sendMessage (/app/node_modules/@adiwajshing/baileys/lib/Socket/messages-send.js:562:17)
```