### PR TITLE
fix: link preview

### DIFF
--- a/src/Utils/link-preview.ts
+++ b/src/Utils/link-preview.ts
@@ -50,6 +50,7 @@ export const getUrlInfo = async(
 
 		const info = await getLinkPreview(previewLink, {
 			...opts.fetchOpts,
+			followRedirects: 'follow',
 			headers: opts.fetchOpts as {}
 		})
 		if(info && 'title' in info && info.title) {


### PR DESCRIPTION
fix #2675
should now actually fix link preview not showing when sending text containing links with `http://` or `https://` prefix